### PR TITLE
WIP: Set theme jekyll-theme-hacker

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-hacker


### PR DESCRIPTION
Enabling GitHub pages in the settings is necessary for this PR to do anything.

Right now, it creates the following pages:
- https://robincsl.github.io/socratic-meetups/
- https://robincsl.github.io/socratic-meetups/meeting-notes/2019-12-03
- https://robincsl.github.io/socratic-meetups/meeting-notes/2020-01-15

I'd suggest we add some section to the README.md where we list the different dates for the navigation to be possible, and on each meeting note, there should be some kind of links to the main page, previous and next notes.

WDYT?